### PR TITLE
Support for reading config from LightwaveRF Gem config files; fix for dimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ A NodeJS library for controlling devices using the LightwaveRF Wi-Fi Link
     var LightwaveRF = require("lightwaverf");
     var lw = new LightwaveRF({ip:"192.168.1.123",email:"name@host.com",pin:"0123"});
 
+Or to read from a [LightwareRF Gem](https://github.com/pauly/lightwaverf) format YAML file:
+
+    var lw = new LightwaveRF({ip:"192.168.1.123", file:"/a/config/file.yml"});
+
 ### Turn a device on
 
 To turn a device on you need to have set it up using the mobile or web app. You need the room ID and the device ID.

--- a/index.js
+++ b/index.js
@@ -347,9 +347,9 @@ LightwaveRF.prototype.getFileConfiguration = function(file, callback) {
                 }).
                 forEach(function (device, deviceIndex) {
                     that.devices.push({
-                        roomId: roomIndex,
+                        roomId: room['id'] ? parseInt(room['id'].substring(1)) : roomIndex + 1,
                         roomName: room['name'],
-                        deviceId: deviceIndex,
+                        deviceId: device['id'] ? parseInt(device['id'].substring(1)) : deviceIndex + 1,
                         deviceName: device['name'],
                         deviceType: device['type']});
                 });
@@ -359,7 +359,7 @@ LightwaveRF.prototype.getFileConfiguration = function(file, callback) {
             callback(that.devices, that);
         }
 
-        //console.log(that.devices); 
+        //console.log(that.devices);
 
     } catch (e) {
         console.log('Unable to read YAML file ' + file);

--- a/index.js
+++ b/index.js
@@ -181,7 +181,12 @@ LightwaveRF.prototype.turnRoomOff = function(roomId, callback) {
  */
 LightwaveRF.prototype.setDeviceDim = function(roomId, deviceId, dimPercentage , callback) {
 	var dimAmount = parseInt(dimPercentage * 0.32, 10); //Dim is on a scale from 0 to 32
-	this.exec("!R" + roomId + "D" + deviceId + "FdP" + dimAmount + "|\0", callback);
+
+    if (dimAmount === 0) {
+        this.turnDeviceOff(roomId, deviceId, callback);
+    } else {
+        this.exec("!R" + roomId + "D" + deviceId + "FdP" + dimAmount + "|\0", callback);
+    }
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -327,7 +327,7 @@ LightwaveRF.prototype.getDevices = function(roomsString,devicesString,typesStrin
         }
     }
     
-    if(callback) callback(this.devices);
+    if(callback) callback(this.devices, this);
     
     //console.log(this.devices);
 }
@@ -356,7 +356,7 @@ LightwaveRF.prototype.getFileConfiguration = function(file, callback) {
         });
 
         if (callback) {
-            callback(that.devices);
+            callback(that.devices, that);
         }
 
         //console.log(that.devices); 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "url": "https://github.com/ollieparsley/node-lightwaverf/issues"
   },
     "dependencies": {
-        "wait.for": ">=0.6.6"
+        "wait.for": ">=0.6.6",
+        "js-yaml": ">=3.5.3"
     }
 }


### PR DESCRIPTION
I've been playing with your `homebridge-lightwaverf` plugin this afternoon and run into a couple of niggles, which this pull request aims to resolve. Hopefully they're generic problems and not just side effects of my setup.

Firstly, home kit was setting the lights to full when dimmed to zero. The same behaviour was exhibited when I used just this module directly. I've fixed it by sending an `off` command when the dim amount becomes equal to 0 - however, given my limited knowledge of protocol I'm unsure as to whether this is a general issue or something odd with my hub/setup.

Secondly, I've added support for reading the configuration from a YAML config file, as per the format used by the LightwaveRF gem. This was due to `lightwaverfhost.co.uk` being deprecated and hence leaving configuration out of sync with the new iOS app. This provides a workaround, albeit a manual one, until they get sorted and give us a new web interface.

Finally, I've added a pointer to the API as a second argument in the callback, which removes the requirement that the callback is called asynchronously.

Thanks very much for all your work in this area, and hope this is of help!
